### PR TITLE
Add ModSecurity force build option

### DIFF
--- a/attributes/modsecurity.rb
+++ b/attributes/modsecurity.rb
@@ -2,5 +2,6 @@
 # Attributes:: modsecurity
 
 default['nginxxx']['modsecurity']['branch'] = 'v3/master'
+default['nginxxx']['modsecurity']['force_build'] = false
 default['nginxxx']['owasp-modsecurity-crs']['branch'] = 'v3.0/master'
 default['nginxxx']['modsecurity-nginx']['branch'] = 'master'

--- a/recipes/modsecurity.rb
+++ b/recipes/modsecurity.rb
@@ -45,6 +45,7 @@ cache_path = Chef::Config[:file_cache_path]
 end
 
 execute 'make_modsecurity' do
+  not_if 'test -d /usr/local/modsecurity' unless node['nginxxx']['modsecurity']['force_build']
   command <<-EOS
   make clean
   sh build.sh
@@ -56,5 +57,4 @@ execute 'make_modsecurity' do
   EOS
   environment 'CFLAGS' => "-DDEFAULT_USER=\\\"#{node['nginxxx']['user']}\\\" -DDEFAULT_GROUP=\\\"#{node['nginxxx']['user']}\\\""
   cwd "/usr/local/src/modsecurity"
-  not_if 'test -d /usr/local/modsecurity'
 end


### PR DESCRIPTION
We couldn't update ModSecurity when already installed it...
So, add `default['nginxxx']['modsecurity']['force_build']` and support forece build option for ModSecurity install recipe.